### PR TITLE
Fixing shell code errors. #112

### DIFF
--- a/prysm/create-prysm-validator-wallet.sh
+++ b/prysm/create-prysm-validator-wallet.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 # This will be passed arguments that start the validator
 while true; do
-  read -p "Will you import keys via the Web UI? (y/n) " yn
+  read -rp "Will you import keys via the Web UI? (y/n) " yn
   case $yn in
-    [Yy]* ) import=0; echo "Skipping import. If you choose to store the wallet password, use the one you created during Web UI wallet creation"; break;;
-    [Nn]* ) import=1; echo "Continuing to key import"; break;;
-    * ) echo "Please answer yes or no.";;
+  [Yy]*)
+    import=0
+    echo "Skipping import. If you choose to store the wallet password, use the one you created during Web UI wallet creation"
+    break
+    ;;
+  [Nn]*)
+    import=1
+    echo "Continuing to key import"
+    break
+    ;;
+  *) echo "Please answer yes or no." ;;
   esac
 done
 
@@ -14,10 +22,9 @@ echo
 if [ $import -ne 0 ]; then
   echo When asked for a wallet directory below, enter /var/lib/prysm
   echo
-  "$@"
 
-  if [ $? -ne 0 ]; then
-    exit 1;
+  if ! "$@"; then
+    exit 1
   fi
   echo
 fi
@@ -25,11 +32,16 @@ fi
 echo Storing the wallet password in plain text will allow the validator to start automatically without user input.
 echo
 while true; do
-  read -p "Do you wish to store the wallet password inside this container? (y/n) " yn
+  read -rp "Do you wish to store the wallet password inside this container? (y/n) " yn
   case $yn in
-    [Yy]* ) break;;
-    [Nn]* ) echo "Not storing plaintext wallet password."; echo; echo "Please adjust prysm-base.yml and see instructions in README.md on how to start the client"; exit;;
-    * ) echo "Please answer yes or no.";;
+  [Yy]*) break ;;
+  [Nn]*)
+    echo "Not storing plaintext wallet password."
+    echo
+    echo "Please adjust prysm-base.yml and see instructions in README.md on how to start the client"
+    exit
+    ;;
+  *) echo "Please answer yes or no." ;;
   esac
 done
 echo
@@ -39,9 +51,9 @@ while true; do
   else
     prompt="Please choose a wallet password, which you will then also provide during Web UI Wallet Creation: "
   fi
-  read -sp "${prompt}" password1
+  read -srp "${prompt}" password1
   echo
-  read -sp "Please re-enter the wallet password: " password2
+  read -srp "Please re-enter the wallet password: " password2
   if [ "$password1" == "$password2" ]; then
     break
   else


### PR DESCRIPTION
Optimizing shell code to align with shellcheck, auto formatting. 
fixes #112

SC2162: read without -r will mangle backslashes.
SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.