### PR TITLE
Allow access to critical ports only from localhost

### DIFF
--- a/eth1-shared.yml
+++ b/eth1-shared.yml
@@ -1,7 +1,7 @@
 # To be used in conjunction with oe.yml, nm.yml, besu.yml or geth.yml
-version: "3.4"
+version: '3.4'
 services:
   eth1:
     ports:
-      - ${ETH1_RPC_PORT}:${ETH1_RPC_PORT}/tcp
-      - ${ETH1_WS_PORT}:${ETH1_WS_PORT}/tcp
+      - 127.0.0.1:127.0.0.1:${ETH1_RPC_PORT}:${ETH1_RPC_PORT}/tcp
+      - 127.0.0.1:${ETH1_WS_PORT}:${ETH1_WS_PORT}/tcp

--- a/eth1-standalone.yml
+++ b/eth1-standalone.yml
@@ -1,10 +1,10 @@
 # To be used in conjunction with oe.yml, nm.yml, besu.yml or geth.yml
-version: "3.4"
+version: '3.4'
 services:
   eth1:
     ports:
-      - ${ETH1_RPC_PORT}:${ETH1_RPC_PORT}/tcp
-      - ${ETH1_WS_PORT}:${ETH1_WS_PORT}/tcp
+      - 127.0.0.1:127.0.0.1:${ETH1_RPC_PORT}:${ETH1_RPC_PORT}/tcp
+      - 127.0.0.1:${ETH1_WS_PORT}:${ETH1_WS_PORT}/tcp
   eth2:
     image: tianon/true
   beacon:

--- a/lh-grafana.yml
+++ b/lh-grafana.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: '3.4'
 services:
   beacon:
     expose:
@@ -15,7 +15,7 @@ services:
       - --metrics-address
       - 0.0.0.0
   prometheus:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./prometheus
     image: prometheus
@@ -26,18 +26,24 @@ services:
     expose:
       - 9090/tcp
     entrypoint: choose-config.sh
-    command: ["/bin/prometheus", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles"]
+    command:
+      [
+        '/bin/prometheus',
+        '--storage.tsdb.path=/prometheus',
+        '--web.console.libraries=/usr/share/prometheus/console_libraries',
+        '--web.console.templates=/usr/share/prometheus/consoles',
+      ]
     depends_on:
       - beacon
       - validator
       - node-exporter
   node-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: prom/node-exporter
     expose:
       - 9100/tcp
   grafana:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./grafana
     image: grafana
@@ -45,8 +51,8 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
-    ports: 
-      - ${GRAFANA_PORT}:3000/tcp
+    ports:
+      - 127.0.0.1:${GRAFANA_PORT}:3000/tcp
   eth2:
     depends_on:
       - grafana

--- a/nimbus-grafana.yml
+++ b/nimbus-grafana.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: '3.4'
 services:
   beacon:
     expose:
@@ -8,7 +8,7 @@ services:
       - --metrics-port=8008
       - --metrics-address=0.0.0.0
   prometheus:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./prometheus
     image: prometheus
@@ -19,17 +19,23 @@ services:
     expose:
       - 9090/tcp
     entrypoint: choose-config.sh
-    command: ["/bin/prometheus", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles"]
+    command:
+      [
+        '/bin/prometheus',
+        '--storage.tsdb.path=/prometheus',
+        '--web.console.libraries=/usr/share/prometheus/console_libraries',
+        '--web.console.templates=/usr/share/prometheus/consoles',
+      ]
     depends_on:
       - beacon
       - node-exporter
   node-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: prom/node-exporter
     expose:
       - 9100/tcp
   grafana:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./grafana
     image: grafana
@@ -37,8 +43,8 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
-    ports: 
-      - ${GRAFANA_PORT}:3000/tcp
+    ports:
+      - 127.0.0.1:${GRAFANA_PORT}:3000/tcp
   eth2:
     depends_on:
       - grafana

--- a/prysm-grafana.yml
+++ b/prysm-grafana.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: '3.4'
 services:
   beacon:
     expose:
@@ -13,7 +13,7 @@ services:
       - --monitoring-host
       - 0.0.0.0
   prometheus:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./prometheus
     image: prometheus
@@ -24,7 +24,13 @@ services:
     expose:
       - 9090/tcp
     entrypoint: choose-config.sh
-    command: ["/bin/prometheus", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles"]
+    command:
+      [
+        '/bin/prometheus',
+        '--storage.tsdb.path=/prometheus',
+        '--web.console.libraries=/usr/share/prometheus/console_libraries',
+        '--web.console.templates=/usr/share/prometheus/consoles',
+      ]
     depends_on:
       - beacon
       - validator
@@ -33,12 +39,12 @@ services:
       - json-exporter
       - cryptowat-exporter
   node-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: prom/node-exporter
     expose:
       - 9100/tcp
   blackbox-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: prom/blackbox-exporter:master
     volumes:
       - ./prometheus/blackbox.yml:/config/blackbox.yml
@@ -47,7 +53,7 @@ services:
     command:
       - --config.file=/config/blackbox.yml
   json-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: quay.io/prometheuscommunity/json-exporter
     volumes:
       - ./prometheus/json.yml:/config/json.yml
@@ -57,7 +63,7 @@ services:
       - --config.file
       - /config/json.yml
   cryptowat-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: nbarrientos/cryptowat_exporter
     environment:
       - CRYPTOWAT_EXCHANGES=kraken
@@ -65,9 +71,9 @@ services:
       - CRYPTOWAT_CACHESECONDS=300
       - TZ=Europe/Zurich
     expose:
-      - 9745/tcp 
+      - 9745/tcp
   grafana:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./grafana
     image: grafana
@@ -76,7 +82,7 @@ services:
     depends_on:
       - prometheus
     ports:
-      - ${GRAFANA_PORT}:3000/tcp
+      - 127.0.0.1:${GRAFANA_PORT}:3000/tcp
   eth2:
     depends_on:
       - grafana

--- a/prysm-web.yml
+++ b/prysm-web.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: '3.4'
 services:
   beacon:
     ports:
@@ -12,7 +12,7 @@ services:
       - --grpc-gateway-corsdomain
       - http://127.0.0.1:7500
       - --grpc-gateway-port
-      - "3500"
+      - '3500'
   validator:
     ports:
       - 7500:7500/tcp
@@ -26,9 +26,9 @@ services:
       - --grpc-gateway-corsdomain
       - http://127.0.0.1:7500
       - --grpc-gateway-port
-      - "7500"
+      - '7500'
   prometheus:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./prometheus
     image: prometheus
@@ -39,7 +39,13 @@ services:
     expose:
       - 9090/tcp
     entrypoint: choose-config.sh
-    command: ["/bin/prometheus", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles"]
+    command:
+      [
+        '/bin/prometheus',
+        '--storage.tsdb.path=/prometheus',
+        '--web.console.libraries=/usr/share/prometheus/console_libraries',
+        '--web.console.templates=/usr/share/prometheus/consoles',
+      ]
     depends_on:
       - beacon
       - validator
@@ -48,12 +54,12 @@ services:
       - json-exporter
       - cryptowat-exporter
   node-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: prom/node-exporter
     expose:
       - 9100/tcp
   blackbox-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: prom/blackbox-exporter:master
     volumes:
       - ./prometheus:/config
@@ -62,7 +68,7 @@ services:
     command:
       - --config.file=/config/blackbox.yml
   json-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: quay.io/prometheuscommunity/json-exporter
     volumes:
       - ./prometheus/json.yml:/config/json.yml
@@ -72,7 +78,7 @@ services:
       - --config.file
       - /config/json.yml
   cryptowat-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: nbarrientos/cryptowat_exporter
     environment:
       - CRYPTOWAT_EXCHANGES=kraken
@@ -80,9 +86,9 @@ services:
       - CRYPTOWAT_CACHESECONDS=300
       - TZ=Europe/Zurich
     expose:
-      - 9745/tcp 
+      - 9745/tcp
   grafana:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./grafana
     image: grafana
@@ -91,7 +97,7 @@ services:
     depends_on:
       - prometheus
     ports:
-      - ${GRAFANA_PORT}:3000/tcp
+      - 127.0.0.1:${GRAFANA_PORT}:3000/tcp
   eth2:
     depends_on:
       - grafana

--- a/teku-grafana.yml
+++ b/teku-grafana.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: '3.4'
 services:
   beacon:
     expose:
@@ -9,7 +9,7 @@ services:
       - --metrics-interface=0.0.0.0
       - --metrics-host-allowlist=*
   prometheus:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./prometheus
     image: prometheus
@@ -20,17 +20,23 @@ services:
     expose:
       - 9090/tcp
     entrypoint: choose-config.sh
-    command: ["/bin/prometheus", "--storage.tsdb.path=/prometheus", "--web.console.libraries=/usr/share/prometheus/console_libraries", "--web.console.templates=/usr/share/prometheus/consoles"]
+    command:
+      [
+        '/bin/prometheus',
+        '--storage.tsdb.path=/prometheus',
+        '--web.console.libraries=/usr/share/prometheus/console_libraries',
+        '--web.console.templates=/usr/share/prometheus/consoles',
+      ]
     depends_on:
       - beacon
       - node-exporter
   node-exporter:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     image: prom/node-exporter
     expose:
       - 9100/tcp
   grafana:
-    restart: "${RESTART}"
+    restart: '${RESTART}'
     build:
       context: ./grafana
     image: grafana
@@ -38,8 +44,8 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
-    ports: 
-      - ${GRAFANA_PORT}:3000/tcp
+    ports:
+      - 127.0.0.1:${GRAFANA_PORT}:3000/tcp
   eth2:
     depends_on:
       - grafana


### PR DESCRIPTION
Docker and ufw both use `iptables` to manage networks. IMHO Docker rules overrride the ufw rules that secure the host. Sometimes it helps just to `sudo ufw reload` after the container start to resolve the issue. But this is not always the case.

There's a [long discussion](https://github.com/docker/for-linux/issues/690) on how to deal with this highly critical issue. Surprisingly for years without a canonical approach.

A very simple/straight forward way to solve this is to **restrict the docker network to expose specific ports only to localhost**:

Example:
<pre>
    ports:
      - ${GRAFANA_PORT}:3000/tcp
</pre>
... changes to: 
<pre>
    ports:
      - <b>127.0.0.1:</b>${GRAFANA_PORT}:3000/tcp
</pre>


I did this for all ports that are noted as 'sensitive' in the `default.env`. Tested successfully for `prysm-grafana.yml`