### PR TITLE
docs(README): use updated Prysm dashboard JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ or [Mainnet launchpad](https://launchpad.ethereum.org). This file was created in
 ## Step 8: Grafana Dashboards
 
 A baseline set of dashboards has been included.  
-- [Metanull's Prysm Dashboard JSON](https://raw.githubusercontent.com/metanull-operator/eth2-grafana/master/eth2-grafana-dashboard-single-source.json)
+- [Metanull's Prysm Dashboard JSON](https://raw.githubusercontent.com/metanull-operator/eth2-grafana/master/eth2-grafana-dashboard-single-source-beacon_node.json)
 - [Prysm Dashboard JSON](https://raw.githubusercontent.com/GuillaumeMiralles/prysm-grafana-dashboard/master/less_10_validators.json)
 - [Prysm Dashboard JSON for more than 10 validators](https://raw.githubusercontent.com/GuillaumeMiralles/prysm-grafana-dashboard/master/more_10_validators.json)
 - [Lighthouse Beacon Dashboard JSON](https://raw.githubusercontent.com/sigp/lighthouse-metrics/master/dashboards/Summary.json)


### PR DESCRIPTION
The dashboard JSON was updated recently to support "beacon node" instead of "beacon". This is the correct dashboard URL to use with eth2-docker.