### PR TITLE
Fix validator-voluntary-exit flag

### DIFF
--- a/lh-base.yml
+++ b/lh-base.yml
@@ -112,7 +112,7 @@ services:
       - account
       - validator
       - exit
-      - --beacon-nodes
+      - --beacon-node
       - http://beacon:5052 
       - --datadir
       - /var/lib/lighthouse


### PR DESCRIPTION
The correct flag here is --beacon-node, not --beacon-nodes. Tested on a pyrmont local build and was able to successfully exit a validator.