### PR TITLE
Update Dockerfile.source

### DIFF
--- a/nethermind/Dockerfile.source
+++ b/nethermind/Dockerfile.source
@@ -1,5 +1,5 @@
 # Partially from Nethermind github
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 # Unused, this is here to avoid build time complaints
 ARG DOCKER_TAG
 


### PR DESCRIPTION
This `5.0.102-ca-patch-buster-slim` tag is no longer needed and is no longer serviced.

Context: https://github.com/dotnet/dotnet-docker/issues/2742

As an aside, do you have any feedback on how .NET container images can be improved? Do they meet your expectations?