### PR TITLE
Traefik

### DIFF
--- a/besu.yml
+++ b/besu.yml
@@ -47,9 +47,6 @@ services:
       - ${LOG_LEVEL}
       - --network
       - ${ETH1_NETWORK}
-  beacon:
-    depends_on:
-      - eth1
   eth2:
     depends_on:
       - eth1

--- a/default.env
+++ b/default.env
@@ -1,7 +1,7 @@
 # Please adjust the below variable to your local user ID if you are on Linux.
 # This is vital for key import to work. You can find your UID with "echo $UID".
 LOCAL_UID=1000
-# Client choice: See SETUP.md for available options
+# Client choice: See https://eth2-docker.net/docs/Usage/ClientSetup for available options
 COMPOSE_FILE=lh-base.yml:geth.yml:lh-grafana.yml
 # ETH1 endpoint / chain source. This default uses the eth1 node container
 # For Lighthouse, you can specify multiple endpoints separated by commas
@@ -22,6 +22,20 @@ LH_PEER_COUNT=50
 TEKU_PEER_COUNT=74
 NIM_PEER_COUNT=160
 
+# Secure web proxy - advanced use, please see instructions
+DOMAIN=example.com
+ACME_EMAIL=user@example.com
+CF_EMAIL=user@example.com
+CF_API_TOKEN=SECRETTOKEN
+AWS_PROFILE=myprofile
+AWS_HOSTED_ZONE_ID=myzoneid
+GRAFANA_HOST=grafana
+PRYSM_HOST=prysm
+ETH1_HOST=eth1
+ETH1_WS_HOST=eth1ws
+DDNS_SUBDOMAIN=
+DDNS_PROXY=true
+
 # P2P ports you will forward to your staking node. Adjust here if you are
 # going to use something other than defaults.
 ETH1_PORT=30303
@@ -34,6 +48,9 @@ TEKU_PORT=9000
 GRAFANA_PORT=3000
 # Local prysm web UI port. Do not expose to Internet, it is insecure http
 PRYSM_WEB_PORT=7500
+# Reverse proxy web port, 443 and 80 are great defaults
+TRAEFIK_WEB_PORT=443
+TRAEFIK_WEB_HTTP_PORT=80
 # ETH1 RPC port, important when using eth1-shared.yml. Also insecure, do not expose to Internet.
 ETH1_RPC_PORT=8545
 # ETH1 WS port, used with Nimbus. Ditto insecure, do not expose to Internet.

--- a/eth1-shared.yml
+++ b/eth1-shared.yml
@@ -5,3 +5,5 @@ services:
     ports:
       - ${ETH1_RPC_PORT}:${ETH1_RPC_PORT}/tcp
       - ${ETH1_WS_PORT}:${ETH1_WS_PORT}/tcp
+  eth2:
+    image: tianon/true

--- a/eth1-standalone.yml
+++ b/eth1-standalone.yml
@@ -1,11 +1,1 @@
-# To be used in conjunction with oe.yml, nm.yml, besu.yml or geth.yml
-version: "3.4"
-services:
-  eth1:
-    ports:
-      - ${ETH1_RPC_PORT}:${ETH1_RPC_PORT}/tcp
-      - ${ETH1_WS_PORT}:${ETH1_WS_PORT}/tcp
-  eth2:
-    image: tianon/true
-  beacon:
-    image: tianon/true
+eth1-shared.yml

--- a/eth1-traefik.yml
+++ b/eth1-traefik.yml
@@ -1,0 +1,19 @@
+# To be used in conjunction with oe.yml, nm.yml, besu.yml or geth.yml
+version: "3.4"
+services:
+  eth1:
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.eth1.service=eth1
+      - traefik.http.routers.eth1.entrypoints=websecure
+      - traefik.http.routers.eth1.rule=Host(`${ETH1_HOST}.${DOMAIN}`)
+      - traefik.http.services.eth1.loadbalancer.server.port=${ETH1_RPC_PORT}
+      - traefik.http.routers.eth1ws.service=eth1ws
+      - traefik.http.routers.eth1ws.entrypoints=websecure
+      - traefik.http.routers.eth1ws.rule=Host(`${ETH1_WS_HOST}.${DOMAIN}`)
+      - traefik.http.services.eth1ws.loadbalancer.server.port=${ETH1_WS_PORT}
+    depends_on:
+      - traefik
+
+  eth2:
+    image: tianon/true

--- a/geth.yml
+++ b/geth.yml
@@ -44,9 +44,6 @@ services:
       - --ws.api
       - eth,net
       - --${ETH1_NETWORK}
-  beacon:
-    depends_on:
-      - eth1
   eth2:
     depends_on:
       - eth1

--- a/grafana-insecure.yml
+++ b/grafana-insecure.yml
@@ -1,0 +1,5 @@
+version: "3.4"
+services:
+  grafana:
+    ports: 
+      - ${GRAFANA_PORT}:${GRAFANA_PORT}/tcp

--- a/lh-grafana.yml
+++ b/lh-grafana.yml
@@ -64,8 +64,13 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
-    ports: 
-      - ${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
+    expose: 
+      - ${GRAFANA_PORT}/tcp
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.entrypoints=web,websecure
+      - traefik.http.routers.grafana.rule=Host(`${GRAFANA_HOST}.${DOMAIN}`)
+      - traefik.http.services.grafana.loadbalancer.server.port=${GRAFANA_PORT}
   eth2:
     depends_on:
       - grafana

--- a/lighthouse/Dockerfile.binary
+++ b/lighthouse/Dockerfile.binary
@@ -28,4 +28,3 @@ USER ${USER}:${USER}
 # For voluntary exit
 ENV KEYSTORE=nonesuch
 
-ENTRYPOINT lighthouse

--- a/lighthouse/Dockerfile.source
+++ b/lighthouse/Dockerfile.source
@@ -45,4 +45,3 @@ USER ${USER}:${USER}
 # For voluntary exit
 ENV KEYSTORE=nonesuch
 
-ENTRYPOINT lighthouse

--- a/nethermind/Dockerfile.source
+++ b/nethermind/Dockerfile.source
@@ -1,5 +1,5 @@
 # Partially from Nethermind github
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 # Unused, this is here to avoid build time complaints
 ARG DOCKER_TAG
 

--- a/nimbus-grafana.yml
+++ b/nimbus-grafana.yml
@@ -55,8 +55,13 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
-    ports: 
-      - ${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
+    expose: 
+      - ${GRAFANA_PORT}/tcp
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.entrypoints=web,websecure
+      - traefik.http.routers.grafana.rule=Host(`${GRAFANA_HOST}.${DOMAIN}`)
+      - traefik.http.services.grafana.loadbalancer.server.port=${GRAFANA_PORT}
   eth2:
     depends_on:
       - grafana

--- a/nm.yml
+++ b/nm.yml
@@ -50,9 +50,6 @@ services:
       - "true"
       - --Pruning.CacheMb
       - "4096"
-  beacon:
-    depends_on:
-      - eth1
   eth2:
     depends_on:
       - eth1

--- a/oe.yml
+++ b/oe.yml
@@ -43,9 +43,6 @@ services:
       - ${LOG_LEVEL}
       - --snapshot-peers
       - "250"
-  beacon:
-    depends_on:
-      - eth1
   eth2:
     depends_on:
       - eth1

--- a/prysm-grafana.yml
+++ b/prysm-grafana.yml
@@ -93,8 +93,13 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
-    ports:
-      - ${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
+    expose:
+      - ${GRAFANA_PORT}/tcp
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.entrypoints=web,websecure
+      - traefik.http.routers.grafana.rule=Host(`${GRAFANA_HOST}.${DOMAIN}`)
+      - traefik.http.services.grafana.loadbalancer.server.port=${GRAFANA_PORT}
   eth2:
     depends_on:
       - grafana

--- a/prysm-web-insecure.yml
+++ b/prysm-web-insecure.yml
@@ -1,0 +1,5 @@
+version: "3.4"
+services:
+  validator:
+    ports: 
+      - ${PRYSM_WEB_PORT}:${PRYSM_WEB_PORT}/tcp

--- a/prysm-web.yml
+++ b/prysm-web.yml
@@ -4,8 +4,8 @@ services:
     expose:
       - 3500/tcp
   validator:
-    ports:
-      - ${PRYSM_WEB_PORT}:${PRYSM_WEB_PORT}/tcp
+    expose:
+      - ${PRYSM_WEB_PORT}/tcp
     entrypoint:
       - validator
       - --datadir
@@ -30,3 +30,8 @@ services:
       # If you chose not to store the wallet password during import, comment out the two following lines
       - --wallet-password-file
       - /var/lib/prysm/password.txt
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.prysm.entrypoints=web,websecure
+      - traefik.http.routers.prysm.rule=Host(`${PRYSM_HOST}.${DOMAIN}`)
+      - traefik.http.services.prysm.loadbalancer.server.port=${PRYSM_WEB_PORT}

--- a/teku-grafana.yml
+++ b/teku-grafana.yml
@@ -56,8 +56,13 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
-    ports: 
-      - ${GRAFANA_PORT}:${GRAFANA_PORT}/tcp
+    expose: 
+      - ${GRAFANA_PORT}/tcp
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.entrypoints=web,websecure
+      - traefik.http.routers.grafana.rule=Host(`${GRAFANA_HOST}.${DOMAIN}`)
+      - traefik.http.services.grafana.loadbalancer.server.port=${GRAFANA_PORT}
   eth2:
     depends_on:
       - grafana

--- a/traefik-aws.yml
+++ b/traefik-aws.yml
@@ -1,0 +1,39 @@
+version: "3.4"
+services:
+  traefik:
+    image: traefik-aws
+    build:
+      context: ./traefik
+    restart: ${RESTART}
+    command:
+#      - --log.level=DEBUG
+#      - --certificatesResolvers.letsencrypt.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --certificatesresolvers.letsencrypt.acme.dnschallenge=true
+      - --certificatesresolvers.letsencrypt.acme.dnschallenge.provider=route53
+      - --certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}
+      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
+      - --entrypoints.web.address=:${TRAEFIK_WEB_HTTP_PORT}
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:${TRAEFIK_WEB_PORT}
+      - --entrypoints.websecure.http.tls=true
+      - --entrypoints.websecure.http.tls.certResolver=letsencrypt
+      - --entrypoints.websecure.http.tls.domains[0].main=${DOMAIN}
+      - --entrypoints.websecure.http.tls.domains[0].sans=*.${DOMAIN}
+    ports:
+      - ${TRAEFIK_WEB_PORT}:${TRAEFIK_WEB_PORT}/tcp    
+      - ${TRAEFIK_WEB_HTTP_PORT}:${TRAEFIK_WEB_HTTP_PORT}/tcp    
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_HOSTED_ZONE_ID=${AWS_HOSTED_ZONE_ID}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - certs:/letsencrypt 
+      - ~/.aws:/root/.aws:ro
+  eth2:
+    depends_on:
+      - traefik
+volumes:
+  certs:

--- a/traefik-cf.yml
+++ b/traefik-cf.yml
@@ -1,0 +1,46 @@
+version: "3.4"
+services:
+  traefik:
+    image: traefik:latest
+    restart: ${RESTART}
+    command:
+#      - --log.level=DEBUG
+#      - --certificatesResolvers.letsencrypt.acme.caServer=https://acme-staging-v02.api.letsencrypt.org/directory
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --certificatesresolvers.letsencrypt.acme.dnschallenge=true
+      - --certificatesresolvers.letsencrypt.acme.dnschallenge.provider=cloudflare
+      - --certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}
+      - --certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json
+      - --entrypoints.web.address=:${TRAEFIK_WEB_HTTP_PORT}
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:${TRAEFIK_WEB_PORT}
+      - --entrypoints.websecure.http.tls=true
+      - --entrypoints.websecure.http.tls.certResolver=letsencrypt
+      - --entrypoints.websecure.http.tls.domains[0].main=${DOMAIN}
+      - --entrypoints.websecure.http.tls.domains[0].sans=*.${DOMAIN}
+    ports:
+      - ${TRAEFIK_WEB_PORT}:${TRAEFIK_WEB_PORT}/tcp    
+      - ${TRAEFIK_WEB_HTTP_PORT}:${TRAEFIK_WEB_HTTP_PORT}/tcp    
+    environment:
+      - CLOUDFLARE_EMAIL=${CF_EMAIL}
+      - CLOUDFLARE_DNS_API_TOKEN=${CF_API_TOKEN}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - certs:/letsencrypt 
+    depends_on:
+      - cf-ddns
+  cf-ddns:
+    image: oznu/cloudflare-ddns:latest
+    restart: ${RESTART}
+    environment:
+      - API_KEY=${CF_API_TOKEN}
+      - ZONE=${DOMAIN}
+      - SUBDOMAIN=${DDNS_SUBDOMAIN}
+      - PROXIED=${DDNS_PROXY}
+  eth2:
+    depends_on:
+      - traefik
+volumes:
+  certs:

--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,0 +1,11 @@
+# Add AWS CLI to traefik image
+
+FROM traefik:latest
+
+RUN apk add --no-cache \
+        python3 \
+        py3-pip \
+    && pip3 install --upgrade pip \
+    && pip3 install \
+        awscli \
+    && rm -rf /var/cache/apk/*

--- a/wizzard.sh
+++ b/wizzard.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# Log everything
+exec 2> ~/eth2-docker.log  # send stderr from to a log file
+exec 1>&2                      # send stdout to the same log file
+set -ex                         # tell sh to display commands before execution
+
+# Don't run as root
+if [[ $EUID -eq 0 ]]; then
+   echo "Do not run as root." 
+   exit 1
+fi
+
+
+# Create ENV file if needed
+ENV_FILE=.env 
+
+if ! [[ -f "$ENV_FILE" ]]; then
+    ENV_FILE_GUESS="$(eval realpath default.env)"
+    ENV_TEMPLATE=$(whiptail --title "Configure ENV_FILE" --inputbox "No $ENV_FILE file found, press enter to use the default, or choose a backup" 10 60 $ENV_FILE_GUESS 3>&1 1>&2 2>&3)
+
+    # Ask the user
+    exitstatus=$?
+    if [ $exitstatus = 0 ]; then
+        echo "your ENV_TEMPLATE is:" $ENV_FILE
+    else
+        echo "You chose Cancel."
+    fi
+
+    # Update The Value in env.
+    cp $ENV_TEMPLATE $ENV_FILE
+fi
+
+# LOCAL_UID
+
+# Guess LOCAL_UID
+LOCAL_UID_GUESS=$(grep LOCAL_UID $ENV_FILE | cut -d "=" -f2 |  sed -e 's/ //g')
+
+LOCAL_UID=$(whiptail --title "Configure LOCAL_UID" --inputbox "What is your LOCAL_UID?" 10 60 $LOCAL_UID_GUESS 3>&1 1>&2 2>&3)
+
+# Ask the user
+exitstatus=$?
+if [ $exitstatus = 0 ]; then
+	echo "your LOCAL_UID is:" $LOCAL_UID
+else
+	echo "You chose Cancel."
+    exit 0
+fi
+
+# Update The Value in env.
+if ! grep -qF "LOCAL_UID" $ENV_FILE 2>/dev/null ; then
+    echo "LOCAL_UID=${LOCAL_UID}" >> $ENV_FILE
+fi
+echo $LOCAL_UID
+sed -i "s/^\(LOCAL_UID\s*=\s*\).*$/\1${LOCAL_UID}/" $ENV_FILE
+
+# ETH1 Client
+
+ETH1_CLIENT=$(whiptail --title "Select Client" --radiolist \
+"What eth1 client do you want to Run?  Choose None for 3rd parties like Infura" 15 60 4 \
+"NONE" "Infura..." ON \
+"geth.yml" "Geth" OFF \
+"nm.yml" "Nethermind" OFF \
+"oe.yml" "OpenEthereum" OFF \
+"besu.yml" "Besu" OFF 3>&1 1>&2 2>&3)
+
+# Ask the user
+exitstatus=$?
+if [ $exitstatus != 0 ]; then exit 0 ; fi
+
+if [ $ETH1_CLIENT = "NONE" ]; then
+	unset ETH1_CLIENT
+fi
+
+
+# ETH2 Client
+
+ETH2_CLIENT=$(whiptail --title "Select Client" --radiolist \
+"What eth2 client?" 15 60 4 \
+"prysm-base.yml" "Prysm" OFF \
+"lh-base.yml" "Lighthouse" ON \
+"teku-base.yml" "Teku" OFF \
+"nimbus-base" "Nimus" OFF 3>&1 1>&2 2>&3)
+
+# Ask the user
+exitstatus=$?
+if [ $exitstatus != 0 ]; then exit 0 ; fi
+
+echo $ETH2_CLIENT
+
+# Use Grafana
+if (whiptail --title "Select Option" --yesno "Use Grafana yes or no." 10 60) then
+	GRAFANA=yes
+else
+	GRAFANA=no
+fi
+
+# Which Grafana should be used
+if [ $GRAFANA = "yes" ]; then
+	GRAFANA_CLIENT=$(echo $(echo $ETH2_CLIENT | cut -d '-' -f1)-grafana.yml)
+else
+	unset GRAFANA_CLIENT
+fi
+
+
+# COMPOSE_FILE
+
+# Guess COMPOSE_FILE
+COMPOSE_FILE_GUESS=${ETH2_CLIENT}:${ETH1_CLIENT}:${GRAFANA_CLIENT}
+
+if ! (whiptail --title "COMPOSE_FILE look good??" --yesno "$COMPOSE_FILE_GUESS." 10 60) then
+    COMPOSE_FILE=$(whiptail --title "Configure COMPOSE_FILE" --inputbox "What is your COMPOSE_FILE?" 10 60 $COMPOSE_FILE_GUESS 3>&1 1>&2 2>&3)	
+else
+    COMPOSE_FILE=${COMPOSE_FILE_GUESS}
+fi
+
+# Ask the user
+exitstatus=$?
+if [ $exitstatus = 0 ]; then
+	echo "your COMPOSE_FILE is:" $COMPOSE_FILE
+else
+	echo "You chose Cancel."
+    exit 0
+fi
+
+# Update The Value in env.
+if ! grep -qF "COMPOSE_FILE" $ENV_FILE 2>/dev/null ; then
+    echo "COMPOSE_FILE=${COMPOSE_FILE}" >> $ENV_FILE
+fi
+echo $COMPOSE_FILE
+sed -i "s/^\(COMPOSE_FILE\s*=\s*\).*$/\1${COMPOSE_FILE}/" $ENV_FILE
+
+
+# Mainnet or Testnet
+# Network
+
+ETH2_NETWORK=$(whiptail --title "Select Network" --radiolist \
+"What network?" 15 60 4 \
+"mainnet" "Production" OFF \
+"pyrmont" "Testnet" ON 3>&1 1>&2 2>&3)
+
+# Update The Value in env.
+if [ $ETH2_NETWORK = "mainnet" ]; then
+    sed -i "s/^\(NETWORK\s*=\s*\).*$/\1mainnet/" $ENV_FILE
+    sed -i "s/^\(ETH1_NETWORK\s*=\s*\).*$/\1mainnet/" $ENV_FILE
+    sed -i "s/^GETH1_NETWORK/# GETH1_NETWORK/" $ENV_FILE
+elif [ $ETH2_NETWORK = "pyrmont" ]; then
+    sed -i "s/^\(NETWORK\s*=\s*\).*$/\1pyrmont/" $ENV_FILE
+    sed -i "s/^\(ETH1_NETWORK\s*=\s*\).*$/\1goerli/" $ENV_FILE
+    sed -i "s/^# GETH1_NETWORK/GETH1_NETWORK/" $ENV_FILE
+else
+	echo "You chose Cancel."
+    exit 0
+fi


### PR DESCRIPTION
Initial traefik setup

Included:
- Traefik for Grafana, tested
- Traefik for Prysm Web, tested
- Traefik for eth1, tested

Choices made:
- Requires CloudFlare or AWS. Rationale: For traefik to work, a DNS entry / domain is needed. Once I have a DNS entry, it is simpler to just do LE certs than to BYOC. CloudFlare adds DDoS protection and is simple to set up.
- DDNS always on CF. For hosts that are not behind NAT, this does not hurt, and it improves the UX a bit: One yml, not two.
- Grafana now defaults to secure mode, and grafana-insecure.yml needs to be specified to map the grafana port to host.
- Prysm Web now defaults to secure mode, and prysm-web-insecure.yml needs to be specified to map the prysm web port to host.
- Rationale for both: This seemed cleaner than duplicating the files entirely and creating lh-grafana-traefik.yml, prysm-grafana-traefik.yml, and so on.

Requirement:
- CF API token needs to have Zone.Zone:Read, Zone.Zone Settings:Read, Zone.DNS:Edit, set this up here:  https://dash.cloudflare.com/profile/api-tokens
- DDNS will set an A record for "domain dot TLD" by default. Create a CNAME record for `grafana` pointing to `@` in CF, ditto for `prysm` if using the Web UI.
- For AWS, a user with sufficient access to Route53 for DNS verification of LE certs
- For AWS, manual creation of A record and any CNAMEs
