### PR TITLE
geth: added web3 http.api option.

### DIFF
--- a/geth.yml
+++ b/geth.yml
@@ -29,7 +29,7 @@ services:
       - 0.0.0.0
       - --http.vhosts=eth1,localhost
       - --http.api
-      - eth,net
+      - eth,net,web3
       - --datadir
       - /var/lib/goethereum
       - --port


### PR DESCRIPTION
the Eth2 validator checklist specifically lists the `web3_clientVersion`
jsonrpc method. Without the `web3` `http.api` option this request will
fail.

Fixes #225 